### PR TITLE
Modifs. proposées pour tester récup partitions et programmation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+LICENSE export-ignore
+Logo export-ignore
+PCB export-ignore
+README.md export-ignore
+Photos export-ignore
+presentation export-ignore
+conception export-ignore
+'boitier 3D' export-ignore
+'test matériel' export-ignore
+Binaire export-ignore
+Sources export-ignore

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -84,6 +84,6 @@ jobs:
       - name: make release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "Gnuvario-E-*.bin,Gnuvario-E-*.partitions.bin"
+          artifacts: "Gnuvario-E-*.bin/*,Gnuvario-E-*.partitions.bin/*"
           tag: ${{ env.NOW }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -14,7 +14,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  - build:
+  build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -72,7 +72,8 @@ jobs:
             path: "arduino_build_${{ matrix.version }}/Gnuvario-E.ino.partitions.bin"
             retention-days: 1
 
-  - release:
+  release:
+    needs: build
     runs-on: ubuntu-latest
     - uses: actions/checkout@v2
     - uses: actions/download-artifact@v2

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -77,8 +77,6 @@ jobs:
     runs-on: ubuntu-latest
     - uses: actions/checkout@v2
     - uses: actions/download-artifact@v2
-      with:
-        name: Gnuvario-E-*.bin
     - name: Display structure of downloaded files
       run: ls -R
 

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -76,13 +76,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
-      - name: Display structure of downloaded files
-        run: ls -R
-
-      # - uses: ncipollo/release-action@v1
-      # with:
-      #   artifacts: "release.tar.gz,foo/*.txt"
-      #   bodyFile: "body.md"
-      #   token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ncipollo/release-action@v1
+        with:
+          artifacts: "Gnuvario-E-*.bin,Gnuvario-E-*.partitions.bin"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -31,26 +31,22 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+
       # Installation de l’outil arduino-cli
       - name: Install Arduino CLI
         uses: arduino/setup-arduino-cli@v1
+
       # Récup index outils expressifs
       - name: Update index
         run: arduino-cli core update-index --additional-urls https://dl.espressif.com/dl/package_esp32_index.json
+
       # Install outils expressifs
       - name: Install core
         run: arduino-cli core install esp32:esp32 --additional-urls https://dl.espressif.com/dl/package_esp32_index.json
-      # Partie à revoir. Pour le moment, je recopie les librairies depuis le dépôt vers le répertoire Arduino
-      #   Finalement : supprimée (à la place, je dis où sont les librairies au moment de la compilation)
-      #- name: install libs
-      #  run: |
-      #    mkdir /home/runner/Arduino
-      #    cp -r "${GITHUB_WORKSPACE}/Sources/Beta Code/Ide Arduino/libraries/" /home/runner/Arduino
-      # Supprimé. À la place, j’ai mis un #ifndef dans le .h. Comme ça, rien ne change pour les autres usages, mais on peut forcer la valeur ici avec -D
-      # - name: patch src
-      #  run: sed -i -e s'|^#define VARIOVERSION|//#define VARIOVERSION|g' "${GITHUB_WORKSPACE}/Sources/Beta Code/Ide Arduino/libraries/HardwareConfig/HardwareConfig.h"
+
       # Compilation, en utilisant -D pour paramétrer les versions.
       - name: compile ${{ matrix.version }}
         run: |
@@ -60,6 +56,7 @@ jobs:
           --output-dir arduino_build_${{ matrix.version }} \
           --libraries "${GITHUB_WORKSPACE}/Sources/Beta Code/Ide Arduino/libraries" \
           "${GITHUB_WORKSPACE}/Sources/Beta Code/Ide Arduino/Gnuvario-E/Gnuvario-E"
+
       # Récup des fichiers compilés
       - name: Upload bin file ${{ matrix.version }}
         uses: actions/upload-artifact@v2.2.3
@@ -67,6 +64,7 @@ jobs:
             name: Gnuvario-E-${{ matrix.version }}.bin
             path: "arduino_build_${{ matrix.version }}/Gnuvario-E.ino.bin"
             retention-days: 1
+
       - name: Upload partition file ${{ matrix.version }}
         uses: actions/upload-artifact@v2.2.3
         with:

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -76,8 +76,13 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v2
-      - uses: ncipollo/release-action@v1
+      - name: set env
+        run: echo "::set-env name=NOW::v$(date +'%Y%m%d.%H%M%S')"
+      - name: download artifacts
+        uses: actions/download-artifact@v2
+      - name: make release
+        uses: ncipollo/release-action@v1
         with:
           artifacts: "Gnuvario-E-*.bin,Gnuvario-E-*.partitions.bin"
+          tag: ${{ env.NOW }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -85,9 +85,9 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifacts: >
-            Gnuvario-E-290.bin,
-            Gnuvario-E-290.partitions.bin,
-            Gnuvario-E-354.bin,
-            Gnuvario-E-354.partitions.bin
+            Gnuvario-E-290.bin/Gnuvario-E-290.bin,
+            Gnuvario-E-290.partitions.bin/Gnuvario-E-290.partitions.bin,
+            Gnuvario-E-354.bin/Gnuvario-E-354.bin,
+            Gnuvario-E-354.partitions.bin/Gnuvario-E-354.partitions.bin
           tag: ${{ env.NOW }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -77,7 +77,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: set env
-        run: echo "::set-env name=NOW::v$(date +'%Y%m%d.%H%M%S')"
+        run: |
+          echo "NOW=v$(date +'%Y%m%d.%H%M%S')" >> $GITHUB_ENV
       - name: download artifacts
         uses: actions/download-artifact@v2
       - name: make release

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -43,10 +43,11 @@ jobs:
       - name: Install core
         run: arduino-cli core install esp32:esp32 --additional-urls https://dl.espressif.com/dl/package_esp32_index.json
       # Partie à revoir. Pour le moment, je recopie les librairies depuis le dépôt vers le répertoire Arduino
-      - name: install libs
-        run: |
-          mkdir /home/runner/Arduino
-          cp -r "${GITHUB_WORKSPACE}/Sources/Beta Code/Ide Arduino/libraries/" /home/runner/Arduino
+      #   Finalement : supprimée (à la place, je dis où sont les librairies au moment de la compilation)
+      #- name: install libs
+      #  run: |
+      #    mkdir /home/runner/Arduino
+      #    cp -r "${GITHUB_WORKSPACE}/Sources/Beta Code/Ide Arduino/libraries/" /home/runner/Arduino
       # Supprimé. À la place, j’ai mis un #ifndef dans le .h. Comme ça, rien ne change pour les autres usages, mais on peut forcer la valeur ici avec -D
       # - name: patch src
       #  run: sed -i -e s'|^#define VARIOVERSION|//#define VARIOVERSION|g' "${GITHUB_WORKSPACE}/Sources/Beta Code/Ide Arduino/libraries/HardwareConfig/HardwareConfig.h"
@@ -57,6 +58,7 @@ jobs:
           -b esp32:esp32:esp32:PSRAM=disabled,PartitionScheme=min_spiffs,CPUFreq=240,FlashMode=qio,FlashFreq=80,FlashSize=4M,UploadSpeed=921600,DebugLevel=none \
           --build-property "build.extra_flags=-DVARIOVERSION=${{ matrix.version }} -DESP32" \
           --output-dir arduino_build_${{ matrix.version }} \
+          --libraries "${GITHUB_WORKSPACE}/Sources/Beta Code/Ide Arduino/libraries" \
           "${GITHUB_WORKSPACE}/Sources/Beta Code/Ide Arduino/Gnuvario-E/Gnuvario-E"
       # Récup des fichiers compilés
       - name: Upload bin file ${{ matrix.version }}

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -75,12 +75,13 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
-    - uses: actions/checkout@v2
-    - uses: actions/download-artifact@v2
-      with:
-        name: Gnuvario-E-*.bin
-    - name: Display structure of downloaded files
-      run: ls -R
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: Gnuvario-E-*.bin
+      - name: Display structure of downloaded files
+        run: ls -R
 
       # - uses: ncipollo/release-action@v1
       # with:

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -14,7 +14,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build:
+  - build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -71,3 +71,18 @@ jobs:
             name: Gnuvario-E-${{ matrix.version }}.partitions.bin
             path: "arduino_build_${{ matrix.version }}/Gnuvario-E.ino.partitions.bin"
             retention-days: 1
+
+  - release:
+    runs-on: ubuntu-latest
+    - uses: actions/checkout@v2
+    - uses: actions/download-artifact@v2
+      with:
+        name: Gnuvario-E-*.bin
+    - name: Display structure of downloaded files
+      run: ls -R
+
+      # - uses: ncipollo/release-action@v1
+      # with:
+      #   artifacts: "release.tar.gz,foo/*.txt"
+      #   bodyFile: "body.md"
+      #   token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -23,10 +23,10 @@ jobs:
       matrix:
         version:
           - 290
-          - 291
-          - 292
-          - 293
-          - 294
+          # - 291
+          # - 292
+          # - 293
+          # - 294
           - 354
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -84,6 +84,10 @@ jobs:
       - name: make release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "Gnuvario-E-*.bin/*,Gnuvario-E-*.partitions.bin/*"
+          artifacts: >
+            Gnuvario-E-290.bin,
+            Gnuvario-E-290.partitions.bin,
+            Gnuvario-E-354.bin,
+            Gnuvario-E-354.partitions.bin
           tag: ${{ env.NOW }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -71,3 +71,18 @@ jobs:
             name: Gnuvario-E-${{ matrix.version }}.partitions.bin
             path: "arduino_build_${{ matrix.version }}/Gnuvario-E.ino.partitions.bin"
             retention-days: 1
+
+  release:
+    runs-on: ubuntu-latest
+    - uses: actions/checkout@v2
+    - uses: actions/download-artifact@v2
+      with:
+        name: Gnuvario-E-*.bin
+    - name: Display structure of downloaded files
+      run: ls -R
+
+      # - uses: ncipollo/release-action@v1
+      # with:
+      #   artifacts: "release.tar.gz,foo/*.txt"
+      #   bodyFile: "body.md"
+      #   token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -33,18 +33,24 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+      # Installation de l’outil arduino-cli
       - name: Install Arduino CLI
         uses: arduino/setup-arduino-cli@v1
+      # Récup index outils expressifs
       - name: Update index
         run: arduino-cli core update-index --additional-urls https://dl.espressif.com/dl/package_esp32_index.json
+      # Install outils expressifs
       - name: Install core
         run: arduino-cli core install esp32:esp32 --additional-urls https://dl.espressif.com/dl/package_esp32_index.json
+      # Partie à revoir. Pour le moment, je recopie les librairies depuis le dépôt vers le répertoire Arduino
       - name: install libs
         run: |
           mkdir /home/runner/Arduino
           cp -r "${GITHUB_WORKSPACE}/Sources/Beta Code/Ide Arduino/libraries/" /home/runner/Arduino
-      - name: patch src
-        run: sed -i -e s'|^#define VARIOVERSION|//#define VARIOVERSION|g' "${GITHUB_WORKSPACE}/Sources/Beta Code/Ide Arduino/libraries/HardwareConfig/HardwareConfig.h"
+      # Supprimé. À la place, j’ai mis un #ifndef dans le .h. Comme ça, rien ne change pour les autres usages, mais on peut forcer la valeur ici avec -D
+      # - name: patch src
+      #  run: sed -i -e s'|^#define VARIOVERSION|//#define VARIOVERSION|g' "${GITHUB_WORKSPACE}/Sources/Beta Code/Ide Arduino/libraries/HardwareConfig/HardwareConfig.h"
+      # Compilation, en utilisant -D pour paramétrer les versions.
       - name: compile ${{ matrix.version }}
         run: |
           arduino-cli compile -v \
@@ -52,9 +58,16 @@ jobs:
           --build-property "build.extra_flags=-DVARIOVERSION=${{ matrix.version }} -DESP32" \
           --output-dir arduino_build_${{ matrix.version }} \
           "${GITHUB_WORKSPACE}/Sources/Beta Code/Ide Arduino/Gnuvario-E/Gnuvario-E"
+      # Récup des fichiers compilés
       - name: Upload bin file ${{ matrix.version }}
         uses: actions/upload-artifact@v2.2.3
         with:
             name: Gnuvario-E-${{ matrix.version }}.bin
             path: "arduino_build_${{ matrix.version }}/Gnuvario-E.ino.bin"
+            retention-days: 1
+      - name: Upload partition file ${{ matrix.version }}
+        uses: actions/upload-artifact@v2.2.3
+        with:
+            name: Gnuvario-E-${{ matrix.version }}.partitions.bin
+            path: "arduino_build_${{ matrix.version }}/Gnuvario-E.ino.partition.sbin"
             retention-days: 1

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -69,5 +69,5 @@ jobs:
         uses: actions/upload-artifact@v2.2.3
         with:
             name: Gnuvario-E-${{ matrix.version }}.partitions.bin
-            path: "arduino_build_${{ matrix.version }}/Gnuvario-E.ino.partition.sbin"
+            path: "arduino_build_${{ matrix.version }}/Gnuvario-E.ino.partitions.bin"
             retention-days: 1

--- a/Sources/Beta Code/Ide Arduino/libraries/HardwareConfig/HardwareConfig.h
+++ b/Sources/Beta Code/Ide Arduino/libraries/HardwareConfig/HardwareConfig.h
@@ -47,10 +47,11 @@
 /*********************************************************************************/
 
 //VERSION
+#ifndef VARIOVERSION
 //#define VARIOVERSION 154     //PCB Version 1 avec ecran 1.54 / PCB version 1 with 1.54" screen
 //#define VARIOVERSION 254     //PCB Version 2 avec ecran 1.54 / PCB Version 2 with 1.54" screen
 //#define VARIOVERSION 290     //PCB Version 2 avec ecran 2.9" paysage / PCB version 2 with 2.9" screen landscape (TTGO-T5-V2.4 before 12/2020)
-//#define VARIOVERSION 291     //PCB Version 2 avec ecran 2.9" portrait / PCB version 2 with 2.9" screen portrait (TTGO-T5-V2.4 before 12/2020)
+#define VARIOVERSION 291     //PCB Version 2 avec ecran 2.9" portrait / PCB version 2 with 2.9" screen portrait (TTGO-T5-V2.4 before 12/2020)
 //#define VARIOVERSION 292     //PCB Version 2 avec ecran 2.9" paysage /PCB version 2 with 2.9" screen landscape  (Ecran/Screen Good Display GDEW029M06)      
 //#define VARIOVERSION 293     //PCB Version 2 avec ecran 2.9" portrait / PCB version 2 with 2.9" screen portrait (Ecran/Screen Good Display GDEW029M06)
 //#define VARIOVERSION 294     //PCB Version 2 avec ecran 2.9" portrait / PCB version 2 with 2.9" screen portrait (TTGO-T5-V2.4 after 12/2020 Screen number DKEG0290BNS800F6 /QYEG0290BNS800F6C02 ) For test purpose only
@@ -61,6 +62,7 @@
 //#define VARIOVERSION 393	   //PCB Version 3.1 avec ecran 2.9" Good Display GDEW029M06 portrait / PCB version 3.1 with 2.9" screen portrait (Ecran/Screen Good Display GDEW029M06) 
 //#define VARIOVERSION 395     //PCB Version 3.5 avec ecran 2.9" paysage (futur BNO085/86)
 //#define VARIOVERSION 396     //PCB Version 3.5 avec ecran 2.9" portrait (futurBNO085/86)
+#endif
 
 #include <HardwareConfigPRO.h>
 #include <HardwareConfigESP32.h>


### PR DESCRIPTION
1/ J’ai re-modifié le hardware config pour qu’il fonctionne comme avant : un VARIOVERSION par défaut.
Mais il est définit que si VARIOVERSION n’existe pas encore. Ça permet de forcer la valeur quand on lance la compilation (paramètre -D)

2/ J’ai tenté de récupérer les fichiers partitions en plus

Ça permettrait de tester la programmation.